### PR TITLE
add virtiofsd support

### DIFF
--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -106,6 +106,22 @@ pub fn get_qemu_args(
 			.map(|s| s.to_string())
 			.collect(),
 		);
+	} else {
+		exec_args.append(
+			&mut [
+				"-chardev",
+				"socket,id=char0,path=/run/vhostqemu",
+				"-device",
+				"vhost-user-fs-pci,queue-size=1024,chardev=char0,tag=mnt",
+				"-object",
+				"memory-backend-file,id=mem,size=1G,mem-path=/dev/shm,share=on",
+				"-numa",
+				"node,memdev=mem",
+			]
+			.iter()
+			.map(|s| s.to_string())
+			.collect(),
+		);
 	}
 
 	let mut args_string = match netconf {

--- a/src/init.rs
+++ b/src/init.rs
@@ -617,7 +617,7 @@ fn init_stage_child(args: SetupArgs) -> ! {
 
 		if micro_vm == 0 {
 			info!("Initialize virtiofsd");
-			let virtiofsd_args: Vec<String> = vec![
+			let virtiofsd_args: Vec<String> = [
 				"virtiofsd",
 				"--socket-path=/run/vhostqemu",
 				"--shared-dir",

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -4,6 +4,8 @@ use std::path;
 pub fn create_spec(bundle: path::PathBuf, args: Vec<String>) {
 	let mut config_file = bundle;
 	config_file.push("config.json");
+	let mut root = runtime::Root::default();
+	root.set_readonly(false.into());
 	let spec: runtime::Spec = runtime::SpecBuilder::default()
 		.process(
 			runtime::ProcessBuilder::default()
@@ -11,6 +13,7 @@ pub fn create_spec(bundle: path::PathBuf, args: Vec<String>) {
 				.build()
 				.unwrap(),
 		)
+		.root(root)
 		.build()
 		.unwrap();
 	spec.save(config_file.to_str().unwrap())


### PR DESCRIPTION
If a hermit application is started and a common VM is used, use virtiofsd to mount /mmt into the VM.