### PR TITLE
add support of a configuration file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,12 +483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,7 +854,6 @@ dependencies = [
  "futures",
  "getset",
  "goblin",
- "lazy_static",
  "libc",
  "log",
  "netlink-packet-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +461,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "indexmap"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +481,12 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -832,6 +860,7 @@ dependencies = [
  "futures",
  "getset",
  "goblin",
+ "lazy_static",
  "libc",
  "log",
  "netlink-packet-core",
@@ -845,6 +874,7 @@ dependencies = [
  "serde_json",
  "time",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -933,6 +963,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
  "serde",
 ]
 
@@ -1117,6 +1156,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,3 +1367,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ command-fds = "0.3"
 futures = "0.3"
 getset = "0.1"
 goblin = { version = "0.9", default-features = false, features = ["elf64", "elf32", "endian_fd"] }
+lazy_static = "1.5.0"
 libc = "0.2"
 log = { version = "0.4", features = ["std"] }
 netlink-packet-core = "0.7"
@@ -35,6 +36,7 @@ nix = { version = "0.29", features = [
     "user",
     "zerocopy",
 ] }
+toml = "0.8.20"
 oci-spec = "0.7"
 path-clean = "1.0"
 procfs = { version = "0.17", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ command-fds = "0.3"
 futures = "0.3"
 getset = "0.1"
 goblin = { version = "0.9", default-features = false, features = ["elf64", "elf32", "endian_fd"] }
-lazy_static = "1.5.0"
 libc = "0.2"
 log = { version = "0.4", features = ["std"] }
 netlink-packet-core = "0.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,40 @@ use crate::spec::*;
 use crate::start::*;
 use crate::state::*;
 use clap::{crate_version, Parser, Subcommand};
+use lazy_static::lazy_static;
+use serde::Deserialize;
 use std::fs::DirBuilder;
 use std::os::unix::fs::DirBuilderExt;
 use std::{env, path::PathBuf};
+
+/// This is what we're going to decode into. Each field is optional, meaning
+/// that it doesn't have to be present in TOML.
+#[derive(Debug, Deserialize)]
+struct Config {
+	kvm: Option<bool>,
+}
+
+impl Config {
+	pub const fn new() -> Self {
+		Self { kvm: None }
+	}
+}
+
+lazy_static! {
+	static ref CONFIG: Config = {
+		match std::fs::read_to_string("/etc/runh/config.toml") {
+			Ok(content) => {
+				let decoded: Result<Config, toml::de::Error> = toml::from_str(&content);
+				if let Ok(config) = decoded {
+					config
+				} else {
+					Config::new()
+				}
+			}
+			Err(_) => Config::new(),
+		}
+	};
+}
 
 fn parse_matches(cli: &Cli) {
 	let project_dir = &cli.root;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,10 +37,10 @@ use crate::start::*;
 use crate::state::*;
 use clap::{crate_version, Parser, Subcommand};
 use serde::Deserialize;
-use std::fs::DirBuilder;
+use std::fs::{read_to_string, DirBuilder};
 use std::os::unix::fs::DirBuilderExt;
 use std::sync::LazyLock;
-use std::{env, path::PathBuf};
+use std::{env, path::Path, path::PathBuf};
 
 /// This is what we're going to decode into. Each field is optional, meaning
 /// that it doesn't have to be present in TOML.
@@ -56,17 +56,19 @@ impl Config {
 }
 
 static CONFIG: LazyLock<Config> =
-	LazyLock::new(|| match std::fs::read_to_string("/etc/runh/config.toml") {
-		Ok(content) => {
-			let decoded: Result<Config, toml::de::Error> = toml::from_str(&content);
-			if let Ok(config) = decoded {
-				config
-			} else {
-				Config::new()
+	LazyLock::new(
+		|| match read_to_string(Path::new("/etc/runh/config.toml")) {
+			Ok(content) => {
+				let decoded: Result<Config, toml::de::Error> = toml::from_str(&content);
+				if let Ok(config) = decoded {
+					config
+				} else {
+					Config::new()
+				}
 			}
-		}
-		Err(_) => Config::new(),
-	});
+			Err(_) => Config::new(),
+		},
+	);
 
 fn parse_matches(cli: &Cli) {
 	let project_dir = &cli.root;


### PR DESCRIPTION
runh reads the file `/etc/runh/config.toml` as configuration file. For instance, the file could have following entries

```toml
# enable/disable KVM support
kvm = false
```

The `kvm` entry defines if runh accelerate the VM by using KVM. In this case, kvm support is disabled.