### PR TITLE
add option to configure the number of cores and the memory size of the VM

### DIFF
--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -30,14 +30,21 @@ pub fn get_qemu_args(
 	kvm_support: bool,
 	tap_fd: &Option<i32>,
 ) -> Vec<String> {
+	let smp: u32 = crate::CONFIG.smp.unwrap_or(1);
+	let memory_size: String = if let Some(memory_size) = crate::CONFIG.memory_size {
+		format!("{}M", memory_size)
+	} else {
+		"1G".to_string()
+	};
+
 	let mut exec_args: Vec<String> = vec![
 		"qemu-system-x86_64",
 		"-display",
 		"none",
 		"-smp",
-		"1",
+		&smp.to_string(),
 		"-m",
-		"1G",
+		&memory_size,
 		"-serial",
 		"stdio",
 		"-device",

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,12 +46,21 @@ use std::{env, path::Path, path::PathBuf};
 /// that it doesn't have to be present in TOML.
 #[derive(Debug, Deserialize)]
 struct Config {
+	/// specifies if KVM support should be enabled
 	kvm: Option<bool>,
+	/// defines the number of cores, which the VM should use
+	smp: Option<u32>,
+	/// define the memory size (in MiB), which the VM should use
+	memory_size: Option<u64>,
 }
 
 impl Config {
 	pub const fn new() -> Self {
-		Self { kvm: None }
+		Self {
+			kvm: None,
+			smp: None,
+			memory_size: None,
+		}
 	}
 }
 


### PR DESCRIPTION
`runh` reads the file `/etc/runh/config.toml`. An example is published below. The entry `kvm` enables the usage of KVM to accelerate the hypervisor. `smp` specifies the number of core, while `memory_size` specifies the memory size (in MiB) für the virtual machine.

```toml
# enable/disable KVM support
kvm = true
# defines the number of cores
smp = 1
# Default memory size in MiB
memory_size = 1024
```